### PR TITLE
(Android) Fix incorrect shadows on VideoPlayer's action buttons

### DIFF
--- a/src/components/feed/VideoPlayer.tsx
+++ b/src/components/feed/VideoPlayer.tsx
@@ -8,6 +8,7 @@ import { useVideoPlayer, VideoView } from 'expo-video';
 import React, { useEffect, useRef, useState } from 'react';
 import {
     Dimensions,
+    Platform,
     Pressable,
     StyleSheet,
     Text,
@@ -430,12 +431,26 @@ const styles = StyleSheet.create({
     },
     actionButton: {
         alignItems: 'center',
-        borderRadius: 50,
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.3,
-        shadowRadius: 3,
-        elevation: 4,
+        ...Platform.select({
+            ios: {
+                borderRadius: 50,
+                shadowColor: '#000',
+                shadowOffset: { width: 0, height: 2 },
+                shadowOpacity: 0.3,
+                shadowRadius: 3,
+            },
+            android: {
+                filter: [
+                {
+                dropShadow: {
+                    offsetX: 0,
+                    offsetY: 2,
+                    standardDeviation: '3px',
+                    color: '#0000004D', // 30% opacity
+                    },
+                }],
+            }
+        })
     },
     avatarContainer: {
         borderWidth: 2,


### PR DESCRIPTION
Android had weird pill shaped shadow on like, comments, bookmark buttons on the main screen.

This solution adds an independant style for Android so it can match the shadow behavior on iOS
(I did not tested the code on iOS, please verify !)

**Before**

![Screenshot_20260108_004120_Loops](https://github.com/user-attachments/assets/0457f016-d618-4ce6-9a3e-988279df3fef)

**After**

<img width="517" height="1073" alt="image" src="https://github.com/user-attachments/assets/2181b5bd-8beb-4e76-ba50-127e599e5645" />


