### PR TITLE
Self profile favorites/likes feed typo

### DIFF
--- a/src/app/(tabs)/profile.tsx
+++ b/src/app/(tabs)/profile.tsx
@@ -149,11 +149,11 @@ export default function ProfileScreen() {
     }, [activeTab, favoritesHasNextPage, likesHasNextPage, videosHasNextPage]);
 
     const handleVideoPress = (video) => {
-        if (!video?.id || !video?.account?.id) {
+        if (!video?.id || !user?.id) {
             console.warn('Invalid video data:', video);
             return;
         }
-        router.push(`/private/profile/feed/${video.id}?profileId=${video.account.id}`);
+        router.push(`/private/profile/feed/${video.id}?profileId=${user.id}`);
     };
 
     const handleSettingsPress = () => {


### PR DESCRIPTION
`When tapping on a favorited or liked video from the user's profile, the navigation uses the video author's account ID instead of the current user's account ID for the profileId parameter.`