### PR TITLE
(UI) Following button uses secondary button theme instead of primary

### DIFF
--- a/src/components/profile/AccountHeader.jsx
+++ b/src/components/profile/AccountHeader.jsx
@@ -139,7 +139,7 @@ export default function AccountHeader(props) {
                             {!state?.blocking && (
                                 <Button
                                     title={state?.following ? 'Following' : 'Follow'}
-                                    theme={state?.following ? 'primary' : 'primary'}
+                                    theme={state?.following ? 'light' : 'primary'}
                                     loading={!state}
                                     style={tw`px-10`}
                                     onPress={props.onFollowPress}


### PR DESCRIPTION
This should make it a more evident visual change when the account is followed by the user, instead of keeping the pink color.

**Before**

<img width="419" height="390" alt="image" src="https://github.com/user-attachments/assets/bf898275-c958-4914-8452-5bc8361a3c2b" />

**After**

<img width="378" height="397" alt="image" src="https://github.com/user-attachments/assets/40e7e978-a1a1-4eca-8da4-d10eb9f40d65" />
