### PR TITLE
(UI) Android navigation bar colors adapts to the app theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "expo-linear-gradient": "~15.0.7",
         "expo-linking": "~8.0.8",
         "expo-media-library": "~18.2.0",
+        "expo-navigation-bar": "~5.0.10",
         "expo-notifications": "~0.32.16",
         "expo-router": "~6.0.14",
         "expo-secure-store": "~15.0.7",
@@ -8247,6 +8248,22 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-navigation-bar": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/expo-navigation-bar/-/expo-navigation-bar-5.0.10.tgz",
+      "integrity": "sha512-r9rdLw8mY6GPMQmVVOY/r1NBBw74DZefXHF60HxhRsdNI2kjc1wLdfWfR2rk4JVdOvdMDujnGrc9HQmqM3n8Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.2",
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-linear-gradient": "~15.0.7",
     "expo-linking": "~8.0.8",
     "expo-media-library": "~18.2.0",
+    "expo-navigation-bar": "~5.0.10",
     "expo-notifications": "~0.32.16",
     "expo-router": "~6.0.14",
     "expo-secure-store": "~15.0.7",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -3,6 +3,7 @@ import { useAuthStore } from '@/utils/authStore';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SplashScreen, Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import * as NavigationBar from 'expo-navigation-bar';
 import React, { useEffect } from 'react';
 import { useColorScheme } from 'react-native';
 import { KeyboardProvider } from "react-native-keyboard-controller";
@@ -19,12 +20,21 @@ function AppContent() {
     const { colorScheme } = useTheme();
     const systemColorScheme = useColorScheme();
 
+    const getNavigationBarStyle = () => {
+        if (colorScheme === 'device') {
+            return systemColorScheme === 'dark' ? NavigationBar.setButtonStyleAsync('light') : NavigationBar.setButtonStyleAsync('dark');
+        }
+        return colorScheme === 'dark' ? NavigationBar.setButtonStyleAsync('light') : NavigationBar.setButtonStyleAsync('dark');
+    };
+
     const getStatusBarStyle = () => {
         if (colorScheme === 'device') {
             return systemColorScheme === 'dark' ? 'light' : 'dark';
         }
         return colorScheme === 'dark' ? 'light' : 'dark';
     };
+
+    getNavigationBarStyle();
 
     return (
         <React.Fragment>


### PR DESCRIPTION
Added expo-navigation-bar & a function to change the style of android's navigation bar.

Not tested on real devices

**Before**

<img width="510" height="277" alt="image" src="https://github.com/user-attachments/assets/eac6594b-d0d4-4e3b-abff-2004c4edc9bb" />


**After**

<img width="508" height="334" alt="image" src="https://github.com/user-attachments/assets/29126a89-9283-470b-9cb1-209f469ce875" />
